### PR TITLE
Awesome WotLK

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -143,6 +143,9 @@ globals = {
 	"DeclensionFrameSetNext",
 	"DeclensionFrameSetPrev",
 
+	-- Awesome WotLK
+	"C_NamePlate",
+
 	-- Lua Std
 	"assert",
 	"bit.arshift",

--- a/ElvUI_ProjectZidras/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI_ProjectZidras/Modules/Nameplates/Nameplates.lua
@@ -468,6 +468,7 @@ end
 
 function ZNP:NAME_PLATE_UNIT_REMOVED(_, unit)
 	local plate = GetNamePlateForUnit(unit)
+	if not plate then return end -- prevent Lua error after Zoning Loading Screen if nameplate was visible prior to zoning
 
 	OnHideHook(plate)
 end


### PR DESCRIPTION
Built over @FrostAtom [library](https://github.com/FrostAtom/awesome_wotlk) that fully replicates retail nameplates, with proper API and events added.
If library is present in the client, PZ will detect it and use this API to better handle nameplates.

https://github.com/Zidras/ElvUI_ProjectZidras/assets/10605951/71ca1066-124c-42e6-8299-8bc70553be9c

Unfortunately, ElvUI is very intrusive on its nameplate handling with OnUpdate scripts and makes some assumptions that collide with this lib, and hinders 3rd-party implementations. This would be best handled directly on ElvUI Nameplates.lua and oUF... Regardless, PZ will attempt to properly preserve nameplate%d caching.
Another consideration for the future is nuking all unit handling (e.g: NP:SetTargetFrame and NP:SetMouseoverFrame) and only keep nameplate events.

