### PR TITLE
NP: re-add Interrupt hold (Fix #24)

### DIFF
--- a/ElvUI_ProjectZidras/Modules/Nameplates/Elements/CastBar.lua
+++ b/ElvUI_ProjectZidras/Modules/Nameplates/Elements/CastBar.lua
@@ -18,6 +18,7 @@ local function resetAttributes(self)
 	self.channeling = nil
 	self.notInterruptible = nil
 	self.spellName = nil
+	self.delay = 0
 end
 
 local function castbarHide(frame)
@@ -95,33 +96,63 @@ function ZNP:Update_CastBarOnValueChanged(value)
 	local min, max = self:GetMinMaxValues()
 	local cur = castBar:GetValue()
 
+	local delta = 0
+	if castBar.casting and cur > value then -- keep this before setting castBar.casting
+		delta = cur - value -- does not produce the same results as UnitCastingInfo math, but I can't justify this being wrong
+	end
+
 	--castBar.spellName = self.Name:GetText()
 	castBar.casting = value > cur
 	castBar.channeling = value < cur
 	castBar.notInterruptible = frame.oldCastBar.Shield:IsShown()
+	castBar.delay = (castBar.delay or 0) + delta
 
 	castBar:SetMinMaxValues(min, max)
 	castBar:SetValue(value)
 
-	if castBar.channeling then
-		if castBar.channelTimeFormat == "CURRENT" then
-			castBar.Time:SetFormattedText("%.1f", abs(value - max))
-		elseif castBar.channelTimeFormat == "CURRENTMAX" then
-			castBar.Time:SetFormattedText("%.1f / %.2f", abs(value - max), max)
-		elseif castBar.channelTimeFormat == "REMAINING" then
-			castBar.Time:SetFormattedText("%.1f", value)
-		elseif castBar.channelTimeFormat == "REMAININGMAX" then
-			castBar.Time:SetFormattedText("%.1f / %.2f", value, max)
+	if castBar.delay ~= 0 then
+		if castBar.channeling then
+			if castBar.channelTimeFormat == "CURRENT" then
+				castBar.Time:SetFormattedText("%.1f |cffaf5050%.2f|r", abs(value - max), castBar.delay)
+			elseif castBar.channelTimeFormat == "CURRENTMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f |cffaf5050%.2f|r", abs(value - max), max, castBar.delay)
+			elseif castBar.channelTimeFormat == "REMAINING" then
+				castBar.Time:SetFormattedText("%.1f |cffaf5050%.2f|r", value, castBar.delay)
+			elseif castBar.channelTimeFormat == "REMAININGMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f |cffaf5050%.2f|r", value, max, max, castBar.delay)
+			end
+		else
+			if castBar.castTimeFormat == "CURRENT" then
+				castBar.Time:SetFormattedText("%.1f |cffaf5050%s %.2f|r", value, "+", castBar.delay)
+			elseif castBar.castTimeFormat == "CURRENTMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f |cffaf5050%s %.2f|r", value, max, "+", castBar.delay)
+			elseif castBar.castTimeFormat == "REMAINING" then
+				castBar.Time:SetFormattedText("%.1f |cffaf5050%s %.2f|r", abs(value - max), "+", castBar.delay)
+			elseif castBar.castTimeFormat == "REMAININGMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f |cffaf5050%s %.2f|r", abs(value - max), max, "+", castBar.delay)
+			end
 		end
 	else
-		if castBar.castTimeFormat == "CURRENT" then
-			castBar.Time:SetFormattedText("%.1f", value)
-		elseif castBar.castTimeFormat == "CURRENTMAX" then
-			castBar.Time:SetFormattedText("%.1f / %.2f", value, max)
-		elseif castBar.castTimeFormat == "REMAINING" then
-			castBar.Time:SetFormattedText("%.1f", abs(value - max))
-		elseif castBar.castTimeFormat == "REMAININGMAX" then
-			castBar.Time:SetFormattedText("%.1f / %.2f", abs(value - max), max)
+		if castBar.channeling then
+			if castBar.channelTimeFormat == "CURRENT" then
+				castBar.Time:SetFormattedText("%.1f", abs(value - max))
+			elseif castBar.channelTimeFormat == "CURRENTMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f", abs(value - max), max)
+			elseif castBar.channelTimeFormat == "REMAINING" then
+				castBar.Time:SetFormattedText("%.1f", value)
+			elseif castBar.channelTimeFormat == "REMAININGMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f", value, max)
+			end
+		else
+			if castBar.castTimeFormat == "CURRENT" then
+				castBar.Time:SetFormattedText("%.1f", value)
+			elseif castBar.castTimeFormat == "CURRENTMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f", value, max)
+			elseif castBar.castTimeFormat == "REMAINING" then
+				castBar.Time:SetFormattedText("%.1f", abs(value - max))
+			elseif castBar.castTimeFormat == "REMAININGMAX" then
+				castBar.Time:SetFormattedText("%.1f / %.2f", abs(value - max), max)
+			end
 		end
 	end
 

--- a/ElvUI_ProjectZidras/Modules/Nameplates/Elements/CastBar.lua
+++ b/ElvUI_ProjectZidras/Modules/Nameplates/Elements/CastBar.lua
@@ -20,6 +20,10 @@ local function resetAttributes(self)
 	self.spellName = nil
 end
 
+local function castbarHide(frame)
+	frame.CastBar:Hide()
+end
+
 local function spellNameWithUnit(self, _, spellName, sourceUnit) -- self, frame, spellName, sourceUnit
 	if not E.db.pz.nameplates.tags.displayTarget.enable or not sourceUnit then return spellName end
 
@@ -187,8 +191,19 @@ function ZNP:Update_CastBar(frame, event, unit)
 			ZNP:Update_CastBarName(frame, unit) -- since on HD this is not hooked and therefore it may not have an event to run ZNP:Update_Tags
 		end
 	elseif event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_INTERRUPTED" then
-		if frame.CastBar:IsShown() then
+		if frame.CastBar and frame.unit == unit then
+			if not frame.CastBar:IsShown() then
+				frame.CastBar:Show()
+			end
+
+			frame.CastBar:SetStatusBarColor(NP.db.colors.castInterruptedColor.r, NP.db.colors.castInterruptedColor.g, NP.db.colors.castInterruptedColor.b)
 			frame.CastBar.Name:SetText(event == "UNIT_SPELLCAST_FAILED" and FAILED or INTERRUPTED)
+
+			frame.CastBar.holdTime = NP.db.units[frame.UnitType].castbar.timeToHold --How long the castbar should stay visible after being interrupted, in seconds
+			frame.CastBar.interrupted = true
+
+			resetAttributes(frame.CastBar)
+			E:Delay(frame.CastBar.holdTime, castbarHide, frame)
 		end
 	end
 end


### PR DESCRIPTION
- [x] Fix missing hold time - [e84aa3a](https://github.com/Zidras/ElvUI_ProjectZidras/pull/25/commits/e84aa3a4094c345137e471eb0663096dfbc27ac4)
- [ ] Fix interrupt color not applying
- [ ] Fix events not passing into Update_CastBar (probably will be migrated into standalone PR)
- [ ] Add CLEU for SPELL_INTERRUPT
- [x] Fix missing delay for casting - [7c41684](https://github.com/Zidras/ElvUI_ProjectZidras/pull/25/commits/7c41684bb47da3dc64fac2a31da8ccf80359c697)
- [ ] Fix missing delay for channeling